### PR TITLE
Allow to register a error handler

### DIFF
--- a/lib/lita.rb
+++ b/lib/lita.rb
@@ -37,6 +37,8 @@ module Lita
     attr_accessor :test_mode
     alias_method :test_mode?, :test_mode
 
+    attr_accessor :error_handler
+
     # The global Logger object.
     # @return [::Logger] The global Logger object.
     def logger
@@ -80,6 +82,8 @@ module Lita
       Robot.new.run
     end
   end
+
+  self.error_handler = -> (_error) {}
 end
 
 require_relative "lita/version"

--- a/lib/lita/handler/chat_router.rb
+++ b/lib/lita/handler/chat_router.rb
@@ -88,6 +88,7 @@ module Lita
         route.callback.call(handler, response)
       rescue Exception => e
         log_dispatch_error(e)
+        Lita.error_handler.call(e)
         raise e if Lita.test_mode?
       end
 

--- a/lib/lita/http_callback.rb
+++ b/lib/lita/http_callback.rb
@@ -18,9 +18,14 @@ module Lita
       if request.head?
         response.status = 204
       else
-        handler = @handler_class.new(env["lita.robot"])
+        begin
+          handler = @handler_class.new(env["lita.robot"])
 
-        @callback.call(handler, request, response)
+          @callback.call(handler, request, response)
+        rescue Exception => e
+          Lita.error_handler.call(e)
+          raise
+        end
       end
 
       response.finish

--- a/spec/lita/handler/chat_router_spec.rb
+++ b/spec/lita/handler/chat_router_spec.rb
@@ -157,6 +157,8 @@ handler = Class.new do
     "Test"
   end
 
+  route(/boom/) { |_response| 1 + "2" }
+
   route(/one/) { |response| response.reply "got one" }
   route(/two/) { |response| response.reply "got two" }
 
@@ -187,6 +189,14 @@ describe handler, lita_handler: true do
     it "doesn't stop dispatching to handlers when there is a matching route in one" do
       send_message("two three")
       expect(replies.last).to eq("got three")
+    end
+  end
+
+  context "when the handler raises an exception" do
+    it "calls Lita.error_handler with the exception as argument" do
+      expect(Lita.error_handler).to receive(:call).with(instance_of(TypeError))
+
+      expect { send_message("boom!") }.to raise_error(TypeError)
     end
   end
 end


### PR DESCRIPTION
The use case is to report exceptions that happen in production to error tracking services (errbit / airbrake / bugsnag / sentry).

The API is as simple as assigning a Proc to `Lita.error_handler`:

```ruby
Lita.error_handler = lambda do |error|
  Airbrake.notify(error)
end
```

@jimmycuadra what do you think of this?

cc @sirupsen