### PR TITLE
Add ability to set base handlers

### DIFF
--- a/lib/lita/rspec/handler.rb
+++ b/lib/lita/rspec/handler.rb
@@ -30,14 +30,14 @@ module Lita
             before do
               if Lita.version_3_compatibility_mode?
                 handler_set = Set.new([described_class])
-                unless base.metadata[:base_handlers].nil?
-                  handler_set.merge(base.metadata[:base_handlers])
+                unless base.metadata[:additional_lita_handlers].nil?
+                  handler_set.merge(base.metadata[:additional_lita_handlers])
                 end
                 allow(Lita).to receive(:handlers).and_return(handler_set)
               else
                 registry.register_handler(described_class)
-                unless base.metadata[:base_handlers].nil?
-                  base.metadata[:base_handlers].each do |h|
+                unless base.metadata[:additional_lita_handlers].nil?
+                  base.metadata[:additional_lita_handlers].each do |h|
                     registry.register_handler(h)
                   end
                 end

--- a/lib/lita/rspec/handler.rb
+++ b/lib/lita/rspec/handler.rb
@@ -29,11 +29,14 @@ module Lita
           base.class_eval do
             before do
               if Lita.version_3_compatibility_mode?
-                handler_set = base.metadata[:base_handlers].nil? ? Set.new([described_class]) : Set.new([described_class]).merge(base.metadata[:base_handlers])
+                handler_set = Set.new([described_class])
+                unless base.metadata[:base_handlers].nil?
+                  handler_set.merge(base.metadata[:base_handlers])
+                end
                 allow(Lita).to receive(:handlers).and_return(handler_set)
               else
                 registry.register_handler(described_class)
-                if !base.metadata[:base_handlers].nil? then
+                unless base.metadata[:base_handlers].nil?
                   base.metadata[:base_handlers].each do |h|
                     registry.register_handler(h)
                   end

--- a/lib/lita/rspec/handler.rb
+++ b/lib/lita/rspec/handler.rb
@@ -29,9 +29,15 @@ module Lita
           base.class_eval do
             before do
               if Lita.version_3_compatibility_mode?
-                allow(Lita).to receive(:handlers).and_return(Set.new([described_class]))
+                handler_set = base.metadata[:base_handlers].nil? ? Set.new([described_class]) : Set.new([described_class]).merge(base.metadata[:base_handlers])
+                allow(Lita).to receive(:handlers).and_return(handler_set)
               else
                 registry.register_handler(described_class)
+                if !base.metadata[:base_handlers].nil? then
+                  base.metadata[:base_handlers].each do |h|
+                    registry.register_handler(h)
+                  end
+                end
               end
             end
           end

--- a/spec/lita/rspec/handler_spec.rb
+++ b/spec/lita/rspec/handler_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+handler_class = Class.new(Lita::Handler) do
+  namespace "testclass"
+  def self.name
+    "Lita::Handlers::Test"
+  end
+end
+
+additional_handler_class = Class.new(Lita::Handler) do
+  namespace "testclass"
+
+  config :test_property, type: String, default: "a string"
+
+  def self.name
+    "Lita::Handlers::TestBase"
+  end
+end
+
+describe handler_class, lita_handler: true, additional_lita_handlers: [additional_handler_class] do
+  describe ":additional_lita_handlers" do
+    it "loads additional handlers into registry" do
+      expect(registry.handlers.include?(additional_handler_class)).to be true
+    end
+
+    it "populates config from additional handlers" do
+      expect(registry.config.handlers.testclass.nil?).to be false
+      expect(registry.config.handlers.testclass.test_property.nil?).to be false
+    end
+  end
+end


### PR DESCRIPTION
This adds a `base_handlers` property that is available when describing an rspec test. Uses a list assuming multiple possible required handlers. This fixes issue #84