### PR TITLE
Fully implement User equality and hashing

### DIFF
--- a/lib/lita/user.rb
+++ b/lib/lita/user.rb
@@ -120,6 +120,12 @@ module Lita
     def ==(other)
       other.respond_to?(:id) && id == other.id && other.respond_to?(:name) && name == other.name
     end
+    alias_method :eql?, :==
+
+    def hash
+      id.hash ^
+        name.hash
+    end
 
     private
 

--- a/spec/lita/user_spec.rb
+++ b/spec/lita/user_spec.rb
@@ -127,16 +127,25 @@ describe Lita::User, lita: true do
     end
   end
 
-  describe "#==" do
+  describe "equality" do
     it "considers two users equal if they share an ID and name" do
       user1 = described_class.new(1, name: "Carl")
       user2 = described_class.new(1, name: "Carl")
       expect(user1).to eq(user2)
+      expect(user1).to eql(user2)
     end
 
     it "doesn't assume the comparison object is a Lita::User" do
       user = described_class.new(1, name: "Carl")
       expect(user).not_to eq("not a Lita::User object")
+      expect(user).not_to eql("not a Lita::User object")
+    end
+
+    it "consistently hashes equal users" do
+      user1 = described_class.new(1, name: "Carl")
+      user2 = described_class.new(1, name: "Carl")
+
+      expect(user1.hash).to eq(user2.hash)
     end
   end
 end


### PR DESCRIPTION
When implementing `#==` an object should also implement `#hash` so that
objects correctly hash for storage in data structures like Hash. In the
same vein, `#eql?` should also be implemented as it is used by Hash and
other data structures to check for member equality.