### PR TITLE
Allow the logging formatting to be configurable.

### DIFF
--- a/lib/lita.rb
+++ b/lib/lita.rb
@@ -40,7 +40,7 @@ module Lita
     # The global Logger object.
     # @return [::Logger] The global Logger object.
     def logger
-      @logger ||= Logger.get_logger(config.robot.log_level)
+      @logger ||= Logger.get_logger(config.robot.log_level, config.robot.log_formatter)
     end
 
     # The root Redis object.

--- a/lib/lita/config.rb
+++ b/lib/lita/config.rb
@@ -45,6 +45,7 @@ module Lita
         config.robot.locale = I18n.locale
         config.robot.log_level = :info
         config.robot.admins = nil
+        config.robot.log_formatter = nil
       end
     end
 

--- a/lib/lita/default_configuration.rb
+++ b/lib/lita/default_configuration.rb
@@ -138,9 +138,9 @@ module Lita
             end
           end
         end
-        config :log_formatter, type: Proc, default: ->(severity, datetime, _progname, msg) {
+        config :log_formatter, type: Proc, default: (lambda do |severity, datetime, _progname, msg|
           "[#{datetime.utc}] #{severity}: #{msg}\n"
-        }
+        end)
         config :admins
         config :error_handler, default: -> (_error) {} do
           validate do |value|

--- a/lib/lita/default_configuration.rb
+++ b/lib/lita/default_configuration.rb
@@ -138,6 +138,7 @@ module Lita
             end
           end
         end
+        config :log_formatter, types: [Proc, NilClass], default: nil
         config :admins
         config :error_handler, default: -> (_error) {} do
           validate do |value|

--- a/lib/lita/default_configuration.rb
+++ b/lib/lita/default_configuration.rb
@@ -138,10 +138,9 @@ module Lita
             end
           end
         end
-        default_formatter = proc do |severity, datetime, _progname, msg|
+        config :log_formatter, type: Proc, default: ->(severity, datetime, _progname, msg) {
           "[#{datetime.utc}] #{severity}: #{msg}\n"
-        end
-        config :log_formatter, type: Proc, default: default_formatter
+        }
         config :admins
         config :error_handler, default: -> (_error) {} do
           validate do |value|

--- a/lib/lita/default_configuration.rb
+++ b/lib/lita/default_configuration.rb
@@ -138,7 +138,10 @@ module Lita
             end
           end
         end
-        config :log_formatter, types: [Proc, NilClass], default: nil
+        default_formatter = proc do |severity, datetime, _progname, msg|
+          "[#{datetime.utc}] #{severity}: #{msg}\n"
+        end
+        config :log_formatter, type: Proc, default: default_formatter
         config :admins
         config :error_handler, default: -> (_error) {} do
           validate do |value|

--- a/lib/lita/logger.rb
+++ b/lib/lita/logger.rb
@@ -6,11 +6,15 @@ module Lita
       # severity level and a custom format.
       # @param level [Symbol, String] The name of the log level to use.
       # @return [::Logger] The {::Logger} object.
-      def get_logger(level)
+      def get_logger(level, formatter = nil)
         logger = ::Logger.new(STDERR)
         logger.level = get_level_constant(level)
-        logger.formatter = proc do |severity, datetime, _progname, msg|
-          "[#{datetime.utc}] #{severity}: #{msg}\n"
+        if formatter && formatter.respond_to?(:call)
+          logger.formatter = formatter
+        else
+          logger.formatter = proc do |severity, datetime, _progname, msg|
+            "[#{datetime.utc}] #{severity}: #{msg}\n"
+          end
         end
         logger
       end

--- a/lib/lita/logger.rb
+++ b/lib/lita/logger.rb
@@ -6,16 +6,10 @@ module Lita
       # severity level and a custom format.
       # @param level [Symbol, String] The name of the log level to use.
       # @return [::Logger] The {::Logger} object.
-      def get_logger(level, formatter = nil)
+      def get_logger(level, formatter)
         logger = ::Logger.new(STDERR)
         logger.level = get_level_constant(level)
-        if formatter && formatter.respond_to?(:call)
-          logger.formatter = formatter
-        else
-          logger.formatter = proc do |severity, datetime, _progname, msg|
-            "[#{datetime.utc}] #{severity}: #{msg}\n"
-          end
-        end
+        logger.formatter = formatter
         logger
       end
 

--- a/lib/lita/logger.rb
+++ b/lib/lita/logger.rb
@@ -6,7 +6,7 @@ module Lita
       # severity level and a custom format.
       # @param level [Symbol, String] The name of the log level to use.
       # @return [::Logger] The {::Logger} object.
-      def get_logger(level, formatter)
+      def get_logger(level, formatter = Lita.config.robot.log_formatter)
         logger = ::Logger.new(STDERR)
         logger.level = get_level_constant(level)
         logger.formatter = formatter


### PR DESCRIPTION
Made it so that you can pass in a proc to the logger and it will use that as the log formatting to accomodate people who want specific log formatting.

I did this because we are deploying our implementation of Lita at Spiceworks and we wanted to change the logger formatting. I have monkey patched this for now but I figured other people may want to be able to format their loggers without having to monkey patch lita so I made a PR to implement it.