### PR TITLE
Allow join from all

### DIFF
--- a/lib/lita/handlers/room.rb
+++ b/lib/lita/handlers/room.rb
@@ -26,7 +26,7 @@ module Lita
       # @param response [Lita::Response] The response object.
       # @return [void]
       def part(response)
-        robot.part(response.args[0])
+        robot.part(response.args[0]) if config.allow_join_from_all_users || robot.auth.user_is_admin?(response.user)
       end
     end
 

--- a/lib/lita/handlers/room.rb
+++ b/lib/lita/handlers/room.rb
@@ -4,11 +4,14 @@ module Lita
     # Allows administrators to make Lita join and part from rooms.
     # @since 3.0.0
     class Room < Handler
-      route(/^join\s+(.+)$/i, :join, command: true, restrict_to: :admins, help: {
+
+      config :allow_join_from_all_users, required: false, default: false
+
+      route(/^join\s+(.+)$/i, :join, command: true, help: {
         t("help.join_key") => t("help.join_value")
       })
 
-      route(/^part\s+(.+)$/i, :part, command: true, restrict_to: :admins, help: {
+      route(/^part\s+(.+)$/i, :part, command: true, help: {
         t("help.part_key") => t("help.part_value")
       })
 
@@ -16,7 +19,7 @@ module Lita
       # @param response [Lita::Response] The response object.
       # @return [void]
       def join(response)
-        robot.join(response.args[0])
+        robot.join(response.args[0]) if config.allow_join_from_all_users || robot.auth.user_is_admin?(response.user)
       end
 
       # Parts from the room with the specified ID.

--- a/lib/lita/handlers/room.rb
+++ b/lib/lita/handlers/room.rb
@@ -4,7 +4,6 @@ module Lita
     # Allows administrators to make Lita join and part from rooms.
     # @since 3.0.0
     class Room < Handler
-
       config :allow_join_from_all_users, required: false, default: false
 
       route(/^join\s+(.+)$/i, :join, command: true, help: {
@@ -19,14 +18,16 @@ module Lita
       # @param response [Lita::Response] The response object.
       # @return [void]
       def join(response)
-        robot.join(response.args[0]) if config.allow_join_from_all_users || robot.auth.user_is_admin?(response.user)
+        robot.join(response.args[0]) if config.allow_join_from_all_users ||
+                                        robot.auth.user_is_admin?(response.user)
       end
 
       # Parts from the room with the specified ID.
       # @param response [Lita::Response] The response object.
       # @return [void]
       def part(response)
-        robot.part(response.args[0]) if config.allow_join_from_all_users || robot.auth.user_is_admin?(response.user)
+        robot.part(response.args[0]) if config.allow_join_from_all_users ||
+                                        robot.auth.user_is_admin?(response.user)
       end
     end
 


### PR DESCRIPTION
I made it so that you can set an option to make it so that anyone can ask lita to join their chat room. Here at Spiceworks we would like anyone to be able to ask Spicebot to join their room without having to bother an admin. I originally monkey patched this but I figured I should make a PR to make this configurable in Lita.