### PR TITLE
adding ruby versions to the travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
   - 2.0.0
+  - 2.1.6
+  - 2.2.2
 script: bundle exec rake
 before_install:
   - gem update --system


### PR DESCRIPTION
I think we should support multiple versions of ruby in case users have reasons
for 2.0 v. 2.1 v. 2.2 so I added the stable builds from each of these in the
travis configs so that the test suite will run against all of these.

If you only want to test against 2.0 that's fine, just close this. If you want to test against multiple versions of ruby then merge away!