### PR TITLE
Move persisted_rooms to not be private.

### DIFF
--- a/lib/lita/robot.rb
+++ b/lib/lita/robot.rb
@@ -162,6 +162,11 @@ module Lita
       end
     end
 
+    # A list of room IDs the robot should join.
+    def persisted_rooms
+      Lita.redis.smembers("persisted_rooms").sort
+    end
+
     private
 
     # Loads and caches the adapter on first access.
@@ -180,11 +185,6 @@ module Lita
       end
 
       adapter_class.new(self)
-    end
-
-    # A list of room IDs the robot should join.
-    def persisted_rooms
-      Lita.redis.smembers("persisted_rooms").sort
     end
 
     # Starts the web server.


### PR DESCRIPTION
We need to move the persisted rooms command on the robot to not be private.
Otherwise the adapters can't access the list of persisted rooms and therefore
can't recconect to them on start up.