### PR TITLE
allow user to send message from a room in tests

### DIFF
--- a/lib/lita/rspec/handler.rb
+++ b/lib/lita/rspec/handler.rb
@@ -78,13 +78,10 @@ module Lita
       # Sends a message to the robot.
       # @param body [String] The message to send.
       # @param as [Lita::User] The user sending the message.
+      # @param as [String] The room where the message is received from.
       # @return [void]
-      def send_message(body, as: user)
-        message = if as == user
-          Message.new(robot, body, source)
-        else
-          Message.new(robot, body, Source.new(user: as))
-        end
+      def send_message(body, as: user, from: nil)
+        Message.new(robot, body, Source.new(user: as, room: from))
 
         robot.receive(message)
       end

--- a/lib/lita/rspec/handler.rb
+++ b/lib/lita/rspec/handler.rb
@@ -81,7 +81,7 @@ module Lita
       # @param as [String] The room where the message is received from.
       # @return [void]
       def send_message(body, as: user, from: nil)
-        Message.new(robot, body, Source.new(user: as, room: from))
+        message = Message.new(robot, body, Source.new(user: as, room: from))
 
         robot.receive(message)
       end

--- a/lib/lita/rspec/handler.rb
+++ b/lib/lita/rspec/handler.rb
@@ -78,7 +78,7 @@ module Lita
       # Sends a message to the robot.
       # @param body [String] The message to send.
       # @param as [Lita::User] The user sending the message.
-      # @param as [String] The room where the message is received from.
+      # @param as [Lita::Room] The room where the message is received from.
       # @return [void]
       def send_message(body, as: user, from: nil)
         message = Message.new(robot, body, Source.new(user: as, room: from))

--- a/spec/lita/rspec_spec.rb
+++ b/spec/lita/rspec_spec.rb
@@ -16,8 +16,12 @@ handler_class = Class.new(Lita::Handler) do
   end
 
   def channel(response)
-    response.reply(response.message.source.room_object.id)
-    response.reply(response.message.source.room_object.name)
+    if (room = response.message.source.room_object)
+      response.reply(room.id)
+      response.reply(room.name)
+    else
+      response.reply("No room")
+    end
   end
 
   def command(response)
@@ -111,6 +115,10 @@ describe handler_class, lita_handler: true do
       room = Lita::Room.create_or_update(1, name: "Room")
       send_message("channel", from: room)
       expect(replies).to eq(%w(1 Room))
+    end
+    it "replies with no channel if not sent from room" do
+      send_message("channel")
+      expect(replies).to eq(["No room"])
     end
   end
 

--- a/spec/lita/rspec_spec.rb
+++ b/spec/lita/rspec_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 handler_class = Class.new(Lita::Handler) do
   route(/^message$/, :message)
+  route(/^channel$/, :channel)
   route(/^command$/, :command, command: true)
   route("restricted", :restricted, restrict_to: :some_group)
   route("admins only", :admins_only, restrict_to: :admins)
@@ -12,6 +13,11 @@ handler_class = Class.new(Lita::Handler) do
 
   def message(response)
     response.reply(response.user.name)
+  end
+
+  def channel(response)
+    response.reply(response.message.source.room_object.id)
+    response.reply(response.message.source.room_object.name)
   end
 
   def command(response)
@@ -37,6 +43,12 @@ describe handler_class, lita_handler: true do
     it { is_expected.to route("message") }
     it { is_expected.to route("message").to(:message) }
     it { is_expected.not_to route("message").to(:not_a_message) }
+  end
+
+  describe "routing channels" do
+    it { is_expected.to route("channel") }
+    it { is_expected.to route("channel").to(:channel) }
+    it { is_expected.not_to route("channel").to(:not_a_channel) }
   end
 
   describe "routing commands" do
@@ -91,6 +103,14 @@ describe handler_class, lita_handler: true do
     it "replies with a string" do
       send_message("message")
       expect(replies).to eq(["Test User"])
+    end
+  end
+
+  describe "#channel" do
+    it "replies with channel id if sent from room" do
+      room = Lita::Room.create_or_update(1, name: "Room")
+      send_message("channel", from: room)
+      expect(replies).to eq(%w(1 Room))
     end
   end
 


### PR DESCRIPTION
Allows developers to write specs that have users sending messages directly to the bot or from a room. Makes it easier to test private and public messages.