### PR TITLE
get the room object from the response

### DIFF
--- a/lib/lita/message.rb
+++ b/lib/lita/message.rb
@@ -12,16 +12,14 @@ module Lita
     attr_reader :source
 
     # @!method user
-    # The user who sent the message.
-    # @return [Lita::User] The user.
-    # @see Lita::Source#user
-    def_delegators :source, :user
-
+    #   The user who sent the message.
+    #   @return [Lita::User] The user.
+    #   @see Lita::Source#user
     # @!method room_object
-    # The room where the message was received from.
-    # @return [Lita::Room] The room.
-    # @see Lita::Source#room_object
-    def_delegators :source, :room_object
+    #   The room where the message came from.
+    #   @return [Lita::Room] The room.
+    #   @see Lita::Source#room_object
+    def_delegators :source, :user, :room_object
 
     # @param robot [Lita::Robot] The currently running robot.
     # @param body [String] The body of the message.

--- a/lib/lita/message.rb
+++ b/lib/lita/message.rb
@@ -17,6 +17,12 @@ module Lita
     # @see Lita::Source#user
     def_delegators :source, :user
 
+    # @!method room_object
+    # The room where the message was received from.
+    # @return [Lita::Room] The room.
+    # @see Lita::Source#room_object
+    def_delegators :source, :room_object
+
     # @param robot [Lita::Robot] The currently running robot.
     # @param body [String] The body of the message.
     # @param source [Lita::Source] The source of the message.

--- a/lib/lita/response.rb
+++ b/lib/lita/response.rb
@@ -27,8 +27,10 @@ module Lita
     #   @see Lita::Message#reply_with_mention
     # @!method user
     #   @see Lita::Message#user
+    # @!method room_object
+    #   @see Lita::Message#room_object
     def_delegators :message, :args, :reply, :reply_privately,
-      :reply_with_mention, :user, :command?
+      :reply_with_mention, :user, :room_object, :command?
 
     # @param message [Lita::Message] The incoming message.
     # @param pattern [Regexp] The pattern the incoming message matched.

--- a/lib/lita/response.rb
+++ b/lib/lita/response.rb
@@ -27,10 +27,12 @@ module Lita
     #   @see Lita::Message#reply_with_mention
     # @!method user
     #   @see Lita::Message#user
-    # @!method room_object
-    #   @see Lita::Message#room_object
     def_delegators :message, :args, :reply, :reply_privately,
-      :reply_with_mention, :user, :room_object, :command?
+      :reply_with_mention, :user, :command?
+
+    # @!method room
+    #   @see Lita::Message#room_object
+    def_delegator :message, :room_object, :room
 
     # @param message [Lita::Message] The incoming message.
     # @param pattern [Regexp] The pattern the incoming message matched.

--- a/spec/lita/message_spec.rb
+++ b/spec/lita/message_spec.rb
@@ -78,6 +78,13 @@ describe Lita::Message do
     end
   end
 
+  describe "#room_object" do
+    it "delegates to #source" do
+      expect(subject.source).to receive(:room_object)
+      subject.room_object
+    end
+  end
+
   describe "#reply" do
     it "sends strings back to the source through the robot" do
       expect(robot).to receive(:send_messages).with(source, "foo", "bar")

--- a/spec/lita/response_spec.rb
+++ b/spec/lita/response_spec.rb
@@ -36,4 +36,18 @@ describe Lita::Response do
       expect(subject.extensions[:foo]).to eq(:bar)
     end
   end
+
+  describe "#user" do
+    it "delegates to #message" do
+      expect(subject.message).to receive(:user)
+      subject.user
+    end
+  end
+
+  describe "#room" do
+    it "delegates to #message" do
+      expect(subject.message).to receive(:room_object)
+      subject.room
+    end
+  end
 end


### PR DESCRIPTION
Currently you can retrieve the user object from a response in your
handler with

```ruby
user = response.user
```

This is how you retrieve a room object before/after this commit

```ruby
# before commit
room = response.message.source.room_object

# after commit
room = response.room_object
```

This better demonstrates the symmetry between a user object and a room
object.