### PR TITLE
Can now check whether a response is a private message

### DIFF
--- a/lib/lita/message.rb
+++ b/lib/lita/message.rb
@@ -19,7 +19,11 @@ module Lita
     #   The room where the message came from.
     #   @return [Lita::Room] The room.
     #   @see Lita::Source#room_object
-    def_delegators :source, :user, :room_object
+    # @!method private_message?
+    #   Flag indicating that the message was sent to the robot privately.
+    #   @return [Boolean] The boolean flag.
+    #   @see Lita::Source#private_message?
+    def_delegators :source, :user, :room_object, :private_message?
 
     # @param robot [Lita::Robot] The currently running robot.
     # @param body [String] The body of the message.

--- a/lib/lita/response.rb
+++ b/lib/lita/response.rb
@@ -27,8 +27,10 @@ module Lita
     #   @see Lita::Message#reply_with_mention
     # @!method user
     #   @see Lita::Message#user
+    # @!method private_message?
+    #   @see Lita::Message#private_message?
     def_delegators :message, :args, :reply, :reply_privately,
-      :reply_with_mention, :user, :command?
+      :reply_with_mention, :user, :private_message?, :command?
 
     # @!method room
     #   @see Lita::Message#room_object

--- a/spec/lita/message_spec.rb
+++ b/spec/lita/message_spec.rb
@@ -85,6 +85,13 @@ describe Lita::Message do
     end
   end
 
+  describe "#private_message?" do
+    it "delegates to #source" do
+      expect(subject.source).to receive(:private_message?)
+      subject.private_message?
+    end
+  end
+
   describe "#reply" do
     it "sends strings back to the source through the robot" do
       expect(robot).to receive(:send_messages).with(source, "foo", "bar")

--- a/spec/lita/response_spec.rb
+++ b/spec/lita/response_spec.rb
@@ -50,4 +50,11 @@ describe Lita::Response do
       subject.room
     end
   end
+
+  describe "#private_message?" do
+    it "delegates to #message" do
+      expect(subject.message).to receive(:private_message?)
+      subject.private_message?
+    end
+  end
 end


### PR DESCRIPTION
Provides an easier alternative into checking whether the response is a
private message, e.g.:

```ruby
# Before commit
response.message.source.private_message?

# After commit
response.private_message?
```

This resolves issue #123