### PR TITLE
Use self instead of repeating the constant name

### DIFF
--- a/templates/plugin/lib/lita/plugin_type/plugin.tt
+++ b/templates/plugin/lib/lita/plugin_type/plugin.tt
@@ -1,16 +1,17 @@
 module Lita
   module <%= config[:constant_namespace] %>
     class <%= config[:constant_name] %><% unless config[:plugin_type] == "extension" %> < <%= config[:plugin_type].capitalize %><% end %>
+      # insert <%= config[:plugin_type] %> code here
+      
+      <%- if config[:plugin_type] == "adapter" -%>
+      Lita.register_adapter(:<%= config[:name] %>, self)
+      <%- elsif config[:plugin_type] == "handler" -%>
+      Lita.register_handler(self)
+      <%- else -%>
+      # If your extension needs to register with a Lita hook, uncomment the
+      # following line and change the hook name to the appropriate value:
+      # Lita.register_hook(:hook_name, self)
+      <%- end -%>
     end
-
-    <%- if config[:plugin_type] == "adapter" -%>
-    Lita.register_adapter(:<%= config[:name] %>, <%= config[:constant_name] %>)
-    <%- elsif config[:plugin_type] == "handler" -%>
-    Lita.register_handler(<%= config[:constant_name] %>)
-    <%- else -%>
-    # If your extension needs to register with a Lita hook, uncomment the
-    # following line and change the hook name to the appropriate value:
-    # Lita.register_hook(:hook_name, <%= config[:constant_name] %>)
-    <%- end -%>
   end
 end


### PR DESCRIPTION
This way the registration survives constant name changes (which is of course a problem I just had 😖).