### PR TITLE
Add user & room ID to info command

### DIFF
--- a/lib/lita/handlers/info.rb
+++ b/lib/lita/handlers/info.rb
@@ -17,6 +17,8 @@ module Lita
       def chat(response)
         response.reply(
           %(Lita #{Lita::VERSION} - https://www.lita.io/),
+          %(This room ID is: #{response.message.source.room}),
+          %(Your user ID is: #{response.message.source.user.id}),
           %(Redis #{redis_version} - Memory used: #{redis_memory_usage})
         )
       end

--- a/spec/lita/handlers/info_spec.rb
+++ b/spec/lita/handlers/info_spec.rb
@@ -22,6 +22,16 @@ describe Lita::Handlers::Info, lita_handler: true do
       send_command("info")
       expect(replies.last).to match(/Redis [\d\.]+ - Memory used: [\d\.]+[BKMG]/)
     end
+
+    it "responds with the user information" do
+      send_command("info")
+      expect(replies).to include("Your user ID is: 1")
+    end
+
+    it "responds with the room information" do
+      send_command("info")
+      expect(replies).to include("This room ID is: ")
+    end
   end
 
   describe "#web" do


### PR DESCRIPTION
So, these were something I was hunting around for, and thought could be
useful as basic information to pass along, especially when getting
started with a new chat system.

I'm not in love with that blank room ID in the test specs, I'll see if I
can add something to fill that in.