### PR TITLE
Rescue and report event handler errors separately

### DIFF
--- a/lib/lita/handler/chat_router.rb
+++ b/lib/lita/handler/chat_router.rb
@@ -86,10 +86,8 @@ module Lita
         robot.hooks[:trigger_route].each { |hook| hook.call(response: response, route: route) }
         handler = new(robot)
         route.callback.call(handler, response)
-      rescue Exception => e
-        log_dispatch_error(e)
-        robot.config.robot.error_handler.call(e)
-        raise e if Lita.test_mode?
+      rescue => error
+        log_dispatch_error(error)
       end
 
       private
@@ -114,16 +112,6 @@ module Lita
           "lita.handler.dispatch",
           handler: name,
           method: route.callback.method_name || "(block)"
-        )
-      end
-
-      # Logs an error encountered during dispatch.
-      def log_dispatch_error(e)
-        Lita.logger.error I18n.t(
-          "lita.handler.exception",
-          handler: name,
-          message: e.message,
-          backtrace: e.backtrace.join("\n")
         )
       end
     end

--- a/lib/lita/handler/common.rb
+++ b/lib/lita/handler/common.rb
@@ -37,6 +37,18 @@ module Lita
         end
 
         alias_method :t, :translate
+
+        # Logs an error encountered during dispatch.
+        def log_dispatch_error(error)
+          Lita.config.robot.error_handler.call(error)
+          Lita.logger.error I18n.t(
+            "lita.handler.exception",
+            handler: name,
+            message: error.message,
+            backtrace: error.backtrace.join("\n")
+          )
+          raise error if Lita.test_mode?
+        end
       end
 
       # A Redis::Namespace scoped to the handler.

--- a/lib/lita/handler/event_router.rb
+++ b/lib/lita/handler/event_router.rb
@@ -57,7 +57,11 @@ module Lita
       # @return [Boolean] Whether or not the event triggered any callbacks.
       def trigger(robot, event_name, payload = {})
         event_subscriptions_for(event_name).map do |callback|
-          callback.call(new(robot), payload)
+          begin
+            callback.call(new(robot), payload)
+          rescue => error
+            log_dispatch_error(error)
+          end
         end.any?
       end
 

--- a/spec/lita/handler/chat_router_spec.rb
+++ b/spec/lita/handler/chat_router_spec.rb
@@ -194,7 +194,7 @@ describe handler, lita_handler: true do
 
   context "when the handler raises an exception" do
     it "calls the error handler with the exception as argument" do
-      expect(registry.config.robot.error_handler).to receive(:call).with(instance_of(TypeError))
+      expect(Lita.config.robot.error_handler).to receive(:call).with(instance_of(TypeError))
 
       expect { send_message("boom!") }.to raise_error(TypeError)
     end


### PR DESCRIPTION
While ideally no exception should happen in production,
when it does in an event handler, it should only break
this particular handler, not the other ones in the chain,
nor the event emitter.

This change provide isolation between event handlers,
so that triggering an event is safe.

@jimmycuadra what do you think?