### PR TITLE
Trigger :message_dispatched event in ChatRouter#dispatch

### DIFF
--- a/lib/lita/handler/chat_router.rb
+++ b/lib/lita/handler/chat_router.rb
@@ -70,6 +70,13 @@ module Lita
         routes.map do |route|
           next unless route_applies?(route, message, robot)
           log_dispatch(route)
+          robot.trigger(
+            :message_dispatched,
+            handler: self,
+            route: route,
+            message: message,
+            robot: robot
+          )
           dispatch_to_route(route, robot, message)
           true
         end.any?

--- a/spec/lita/handler/chat_router_spec.rb
+++ b/spec/lita/handler/chat_router_spec.rb
@@ -104,6 +104,11 @@ describe handler, lita_handler: true do
       end
     end
 
+    it "triggers a message_dispatched event" do
+      expect(robot).to receive(:trigger).with(:message_dispatched, anything)
+      send_message("message")
+    end
+
     it "raises exceptions in test mode" do
       expect { send_message("error") }.to raise_error(RuntimeError)
     end


### PR DESCRIPTION
This makes a payload containing the handler name, route, message, and robot accessible by a handler whenever a message is dispatched.