### PR TITLE
Accept adapter specific messages

### DIFF
--- a/lib/lita/robot.rb
+++ b/lib/lita/robot.rb
@@ -120,10 +120,22 @@ module Lita
     # @param target [Lita::Source] The user or room to send to. If the Source
     #   has a room, it will choose the room. Otherwise, it will send to the
     #   user.
-    # @param strings [String, Array<String>] One or more strings to send.
+    # @param messages [Object, Array<Object>] One or more messages to send. If
+    #   the message has any "to_<adapter>" method (eg.: to_shell), the result of
+    #   this method will be sent to adapter, otherwise "to_s" will be called.
     # @return [void]
-    def send_messages(target, *strings)
-      adapter.send_messages(target, strings.flatten)
+    def send_messages(target, *messages)
+      message_method = "to_#{config.robot.adapter}".to_sym
+
+      messages = messages.flatten.map do |message|
+        if message.respond_to?(message_method)
+          message.send(message_method, adapter)
+        else
+          message.to_s
+        end
+      end
+
+      adapter.send_messages(target, messages)
     end
     alias_method :send_message, :send_messages
 
@@ -132,18 +144,27 @@ module Lita
     # @param target [Lita::Source] The user or room to send to. If the Source
     #   has a room, it will choose the room. Otherwise, it will send to the
     #   user.
-    # @param strings [String, Array<String>] One or more strings to send.
+    # @param messages [Object, Array<Object>] One or more messages to send. If
+    #   the message has the "mention=" method, it'll be called with the mention
+    #   string, otherwise the mention will be prepended to the message.
     # @return [void]
     # @since 3.1.0
-    def send_messages_with_mention(target, *strings)
-      return send_messages(target, *strings) if target.private_message?
+    def send_messages_with_mention(target, *messages)
+      return send_messages(target, *messages) if target.private_message?
 
       mention_name = target.user.mention_name
-      prefixed_strings = strings.map do |s|
-        "#{adapter.mention_format(mention_name).strip} #{s}"
+      mention = adapter.mention_format(mention_name).strip
+
+      messages = messages.map do |message|
+        if message.respond_to?(:mention=)
+          message.mention = mention
+          message
+        else
+          "#{mention} #{message}"
+        end
       end
 
-      send_messages(target, *prefixed_strings)
+      send_messages(target, *messages)
     end
     alias_method :send_message_with_mention, :send_messages_with_mention
 

--- a/spec/lita/robot_spec.rb
+++ b/spec/lita/robot_spec.rb
@@ -209,6 +209,34 @@ describe Lita::Robot, lita: true do
       )
       subject.send_messages(source, "foo", "bar")
     end
+
+    it "translate the message to current adapter" do
+      message = double("message")
+      expect(message).to receive(:to_shell).with(
+        instance_of(Lita::Adapters::Shell)
+      ).and_return("foo")
+
+      expect_any_instance_of(
+        Lita::Adapters::Shell
+      ).to receive(:send_messages).with(
+        source, %w(foo bar)
+      )
+
+      subject.send_messages(source, message, "bar")
+    end
+
+    it "translate the message to another adapter" do
+      message = double("message")
+      expect(message).to receive(:to_s).and_return("foo")
+
+      expect_any_instance_of(
+        Lita::Adapters::Shell
+      ).to receive(:send_messages).with(
+        source, %w(foo bar)
+      )
+
+      subject.send_messages(source, message, "bar")
+    end
   end
 
   describe "#send_message_with_mention" do
@@ -247,6 +275,23 @@ describe Lita::Robot, lita: true do
       )
 
       subject.send_messages_with_mention(source, "foo", "bar")
+    end
+
+    it "delegates mention name to message builder when provided" do
+      message = double("message")
+      expect(message).to receive(:mention=).with("carl:")
+      expect(message).to receive(:to_s).and_return("carl: foo")
+
+      allow_any_instance_of(Lita::Adapters::Shell).to receive(:mention_format).with(
+        "carl"
+      ).and_return("carl:")
+
+      expect_any_instance_of(Lita::Adapters::Shell).to receive(:send_messages).with(
+        source,
+        ["carl: foo", "carl: bar"]
+      )
+
+      subject.send_messages_with_mention(source, message, "bar")
     end
   end
 


### PR DESCRIPTION
I put this approach in discussion at https://github.com/kenjij/lita-slack/issues/30.

The idea here is that the **handler** can create a class, implementing any `to_adapter` methods it can support, and lita would call the adapter correspondent method. If the adapter isn't supported, a fallback to_s method must exist. Here is a sample class that the handler could create:

``` ruby
class Message
  def initialize(message)
    @message = message
  end

  def to_slack
    @message
  end

  def to_s
    @message[:text]
  end
end
```