### PR TITLE
Use SVG badges for coveralls and Travis CI

### DIFF
--- a/templates/plugin/README.tt
+++ b/templates/plugin/README.tt
@@ -2,10 +2,10 @@
 
 <%- if config[:badges] -%>
 <%- if config[:travis] -%>
-[![Build Status](https://travis-ci.org/<%= config[:github_user] %>/<%= config[:gem_name] %>.png?branch=master)](https://travis-ci.org/<%= config[:github_user] %>/<%= config[:gem_name] %>)
+[![Build Status](https://travis-ci.org/<%= config[:github_user] %>/<%= config[:gem_name] %>.svg?branch=master)](https://travis-ci.org/<%= config[:github_user] %>/<%= config[:gem_name] %>)
 <%- end -%>
 <%- if config[:coveralls] -%>
-[![Coverage Status](https://coveralls.io/repos/<%= config[:github_user] %>/<%= config[:gem_name] %>/badge.png)](https://coveralls.io/r/<%= config[:github_user] %>/<%= config[:gem_name] %>)
+[![Coverage Status](https://coveralls.io/repos/<%= config[:github_user] %>/<%= config[:gem_name] %>/badge.svg)](https://coveralls.io/github/<%= config[:github_user] %>/<%= config[:gem_name]?branch=master %>)
 <%- end -%>
 <%- if config[:travis] || config[:coveralls] -%>
 


### PR DESCRIPTION
Noticed that the template still uses PNG images when creating a new plugin just today, see https://github.com/nTraum/lita-down/commit/4b9ea18d5134ae5dc1238bf5091c6dec586286b8.