### PR TITLE
Use new hash-style access for Redis in robot config template

### DIFF
--- a/templates/robot/lita_config.rb
+++ b/templates/robot/lita_config.rb
@@ -24,8 +24,8 @@ Lita.configure do |config|
   # config.adapter.password = "secret"
 
   ## Example: Set options for the Redis connection.
-  # config.redis.host = "127.0.0.1"
-  # config.redis.port = 1234
+  # config.redis[:host] = "127.0.0.1"
+  # config.redis[:port] = 1234
 
   ## Example: Set configuration for any loaded handlers. See the handler's
   ## documentation for options.


### PR DESCRIPTION
As mentioned in [Lita 4.0 release notes](http://docs.lita.io/releases/4/).

> The redis configuration attribute is now a hash. Lita 4 will continue to support struct-style access, but only hash-style access will be supported in Lita 5, so you should update now.