### PR TITLE
byebug won't work on JRuby

### DIFF
--- a/templates/plugin/gemspec.tt
+++ b/templates/plugin/gemspec.tt
@@ -17,7 +17,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "lita", ">= <%= config[:required_lita_version] %>"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "pry-byebug"
+  if RUBY_PLATFORM != 'java'
+    spec.add_development_dependency "pry-byebug"
+  end
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", ">= 3.0.0"


### PR DESCRIPTION
Since it has a C-extension.

So don't require it when run on JRuby.