### PR TITLE
Make root redis namespace configurable

### DIFF
--- a/lib/lita.rb
+++ b/lib/lita.rb
@@ -12,9 +12,6 @@ require_relative "lita/robot"
 # The main namespace for Lita. Provides a global registry of adapters and
 # handlers, as well as global configuration, logger, and Redis store.
 module Lita
-  # The base Redis namespace for all Lita data.
-  REDIS_NAMESPACE = "lita"
-
   class << self
     include Registry::Mixins
 

--- a/lib/lita/message.rb
+++ b/lib/lita/message.rb
@@ -1,4 +1,5 @@
 require "forwardable"
+require "shellwords"
 
 module Lita
   # Represents an incoming chat message.

--- a/lib/lita/registry.rb
+++ b/lib/lita/registry.rb
@@ -60,7 +60,7 @@ module Lita
       def redis
         @redis ||= begin
           redis = Redis.new(config.redis)
-          Redis::Namespace.new(REDIS_NAMESPACE, redis: redis).tap do |client|
+          Redis::Namespace.new(redis_namespace, redis: redis).tap do |client|
             begin
               client.ping
             rescue Redis::BaseError => e
@@ -77,6 +77,12 @@ module Lita
             end
           end
         end
+      end
+
+      # The redis namespace
+      # @return [String] A string that is the root redis namespace
+      def redis_namespace
+        config.redis[:namespace] || "lita"
       end
 
       # @overload register_adapter(key, adapter)

--- a/lib/lita/rspec.rb
+++ b/lib/lita/rspec.rb
@@ -29,7 +29,9 @@ module Lita
           let(:registry) { Registry.new }
 
           before do
-            stub_const("Lita::REDIS_NAMESPACE", "lita.test")
+            allow(Lita).to receive(:redis_namespace).and_return "lita.test"
+            allow_any_instance_of(Lita::Registry).to(
+              receive(:redis_namespace).and_return "lita.test")
             keys = Lita.redis.keys("*")
             Lita.redis.del(keys) unless keys.empty?
           end


### PR DESCRIPTION
In order to run multiple bots on my machine for testing purposes I'd like to be able to split the namespace to be bot specific. I'm not that familiar with redis, so there might be a better way to do this and I'd be happy to use that.

This adds another config option to the redis hash (namespace) and defaults to "lita" just like before.

I would like to add some tests around the new config option, but I didn't see any tests around config, so I wasn't sure where to start with that. (It's quite possible I missed them).